### PR TITLE
Overloads setHighlighted function

### DIFF
--- a/UIImageViewAligned/UIImageViewAligned.m
+++ b/UIImageViewAligned/UIImageViewAligned.m
@@ -180,6 +180,13 @@
 }
 
 
+#pragma mark - UIImageView overloads
+
+- (void)setHighlighted:(BOOL)highlighted {
+    [super setHighlighted:highlighted];
+    self.layer.contents = nil;
+}
+
 #pragma mark - Properties needed for Interface Builder
 
 - (BOOL)alignLeft


### PR DESCRIPTION
- Needs to clear the layer contents to prevent the image from being drawn twice

Fixes #4
