### PR TITLE
Fix misspelling of 'UIImageViewAignmentMask' to 'UIImageViewAlignmentMask

### DIFF
--- a/UIImageViewAligned/UIImageViewAligned.h
+++ b/UIImageViewAligned/UIImageViewAligned.h
@@ -22,14 +22,16 @@ typedef enum
     UIImageViewAlignmentMaskTopLeft = UIImageViewAlignmentMaskTop | UIImageViewAlignmentMaskLeft,
     UIImageViewAlignmentMaskTopRight = UIImageViewAlignmentMaskTop | UIImageViewAlignmentMaskRight,
     
-}UIImageViewAignmentMask;
+}UIImageViewAlignmentMask;
+
+typedef UIImageViewAlignmentMask UIImageViewAignmentMask __attribute__((deprecated("Use UIImageViewAlignmentMask. Use of UIImageViewAignmentMask (misspelled) is deprecated.")));
 
 
 
 @interface UIImageViewAligned : UIImageView
 
 // This property holds the current alignment
-@property (nonatomic) UIImageViewAignmentMask alignment;
+@property (nonatomic) UIImageViewAlignmentMask alignment;
 
 // Properties needed for Interface Builder quick setup
 @property (nonatomic) BOOL alignLeft;

--- a/UIImageViewAligned/UIImageViewAligned.m
+++ b/UIImageViewAligned/UIImageViewAligned.m
@@ -87,7 +87,7 @@
     [self setNeedsLayout];
 }
 
-- (void)setAlignment:(UIImageViewAignmentMask)alignment
+- (void)setAlignment:(UIImageViewAlignmentMask)alignment
 {
     if (_alignment == alignment)
         return ;


### PR DESCRIPTION
Deprecated UIImageViewAignmentMask
