### PR TITLE
Fix issue with UITableViews and UIImageViewAligned

### DIFF
--- a/UIImageViewAligned/UIImageViewAligned.m
+++ b/UIImageViewAligned/UIImageViewAligned.m
@@ -187,6 +187,20 @@
     self.layer.contents = nil;
 }
 
+#pragma mark - UIView overloads
+
+- (void)didMoveToWindow
+{
+    [super didMoveToWindow];
+    self.layer.contents = nil;
+}
+
+- (void)didMoveToSuperview
+{
+    [super didMoveToSuperview];
+    self.layer.contents = nil;
+}
+
 #pragma mark - Properties needed for Interface Builder
 
 - (BOOL)alignLeft


### PR DESCRIPTION
The issue with UITableViewCell is that it doesn't seem to call layoutSubviews when it gets redisplayed after a de-selection when returning from another UIViewController (i.e we just popped one off the stack).
This soles the issue as when we return didMoveToWindow is called.
I added in didMoveToSuperview for good measure, in my testing it didn't seem to have an effect but it may help elsewhere.
