### PR TITLE
Implement sizeThatFits

### DIFF
--- a/UIImageViewAligned/UIImageViewAligned.m
+++ b/UIImageViewAligned/UIImageViewAligned.m
@@ -238,4 +238,9 @@
         self.alignment &= ~UIImageViewAlignmentMaskBottom;
 }
 
+- (CGSize)sizeThatFits:(CGSize)size {
+    return [self.realImageView sizeThatFits:size];
+}
+
+
 @end


### PR DESCRIPTION
UIView sizeThatFits was returning CGSizeZero, documentation says that a UIImageView should return the CGSize of UIImage being displayed.

Without this, some layout engine logic will not work properly